### PR TITLE
Fix: Package Name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ flutter packages get
 Add `Scandit` widget to the tree
 
 ```dart
-import 'package:flutter_scandit/flutter_scandit.dart';
+import 'package:flutter_scandit_plugin/flutter_scandit_plugin.dart';
 
 ScanditController _controller;
 


### PR DESCRIPTION
The example as proposed in the README does not work due to the package renaming. This PR updates the REAMDE with working code.